### PR TITLE
Small changes to make life easier

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,7 @@ Example stdout
 --------------
 In this example below, the commandline we use is::
 
-    locustauto --load_time 360 --ramp_up_time 300 --max_users 300 --max_user_hatch_rate 300 
-    --steps 12 --directory mobile_api --host="http://url-of-the-load-test-env"
+    locustauto --load_time 360 --ramp_up_time 300 --max_users 300 --max_user_hatch_rate 300 --steps 12 --directory mobile_api --host="https://url-of-the-load-test-env"
 
 This test will be using the file in the `directory` called mobile_api against the endpoint set in `host`
   

--- a/locust_auto_test.py
+++ b/locust_auto_test.py
@@ -7,9 +7,9 @@ import subprocess
 import sys
 import time
 import yaml
+from datetime import datetime
 
 IGNORABLE_WARNING = "InsecureRequestWarning"
-
 
 def execute_load_test(command, load_time):
     """
@@ -174,7 +174,7 @@ def process_results(result_list, auto_test_command, config_dict):
     result_keys = ""
     result_values = ""
 
-    file_name = "stats_{}".format(int(time.time()))
+    file_name = datetime.now().strftime('stats_%Y-%m-%d_%H-%M-%S')
 
     with open(file_name, 'w') as f: # pylint: disable=invalid-name
         # add commandline and env variables


### PR DESCRIPTION
- Make the command line string in your README on one line so I can copy-paste it into my terminal
- Make the command line string in your README  use https because https is good
- (most importantly) Make it output files with names like stats_2015-06-03_10-13-32 instead of stats_1203947102938
